### PR TITLE
[DT-044179] Project-level OAuth Tokens Missing in OneDrive Dropdown

### DIFF
--- a/Decisions.MSOneDrive/Decisions.MSOneDrive.csproj
+++ b/Decisions.MSOneDrive/Decisions.MSOneDrive.csproj
@@ -3,11 +3,11 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DecisionsSDK" Version="9.0.1-beta" />
+    <PackageReference Include="DecisionsSDK" Version="9.8.0" />
     <PackageReference Include="Microsoft.Graph" Version="3.29.0" />
   </ItemGroup>
 </Project>

--- a/Decisions.MSOneDrive/Steps/AbstractStep.cs
+++ b/Decisions.MSOneDrive/Steps/AbstractStep.cs
@@ -8,11 +8,12 @@ using DecisionsFramework.Design.Properties.Attributes;
 using DecisionsFramework.ServiceLayer.Services.ContextData;
 using Microsoft.Graph;
 using System;
+using DecisionsFramework.Design.Flow.Interface;
 
 namespace Decisions.MSOneDrive
 {
     [Writable]
-    public abstract class AbstractStep : ISyncStep, IDataConsumer, IDataProducer
+    public abstract class AbstractStep : ISyncStep, IDataConsumer, IDataProducer, IEntityPickerLocation, IFlowAwareStep
     {
         public const string MsOneDriveCategory = "Integration/MS OneDrive";
 
@@ -67,6 +68,16 @@ namespace Decisions.MSOneDrive
                 return token.TokenData;
             throw new EntityNotFoundException($"Can not find token with TokenId=\"{id}\"");
         }
+        
+        [PropertyHidden(true)] 
+        public Flow Flow { get; set; }
+        
+        [PropertyHidden(true)] 
+        public FlowStep FlowStep { get; set; }
+        
+        [PropertyHidden(true)] 
+        public string EntityPickerFolderId => Flow?.EntityFolderID;
+
         public ResultData Run(StepStartData data)
         {
             try
@@ -101,7 +112,6 @@ namespace Decisions.MSOneDrive
         }
 
         protected abstract OneDriveBaseResult ExecuteStep(GraphServiceClient connection, StepStartData data);
-
     }
 }
 

--- a/Module.Build.json
+++ b/Module.Build.json
@@ -18,7 +18,7 @@
 		"ObjectsToImport": null,
 		"MsSqlScript": null
     },
-    "Version": "9.0.0",
+    "Version": "9.12.0",
     "ImagePath": "./image.png",
     "Description": "Module to manage files and folders in MS OneDrive."
 }


### PR DESCRIPTION
This module was never updated to support project level oauth tokens. I have added the necessary interfaces to the base step class so that the token picker can find the tokens